### PR TITLE
Fix lint and type errors for CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,3 +53,8 @@ strict = true
 [[tool.mypy.overrides]]
 module = "grpc.*"
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["asyncpg", "asyncpg.*", "google.protobuf.*"]
+ignore_missing_imports = true
+follow_imports = "skip"

--- a/src/handlers/readings.py
+++ b/src/handlers/readings.py
@@ -15,12 +15,12 @@ logger = logging.getLogger(__name__)
 
 class CollectorHandler(CollectorServiceServicer):
     @inject
-    async def GetLatestReadings(
+    async def GetLatestReadings(  # type: ignore[override]
         self,
-        request,
+        request: collector_pb.GetLatestReadingsRequest,
         context: grpc.aio.ServicerContext,
         readings_service: FromDishka[ReadingsService],
-    ):
+    ) -> collector_pb.GetLatestReadingsResponse:
         try:
             readings = await readings_service.get_latest(request.device_id)
         except ValueError as e:
@@ -34,12 +34,12 @@ class CollectorHandler(CollectorServiceServicer):
         return collector_pb.GetLatestReadingsResponse(readings=proto_readings)
 
     @inject
-    async def DeleteReadings(
+    async def DeleteReadings(  # type: ignore[override]
         self,
-        request,
+        request: collector_pb.DeleteReadingsRequest,
         context: grpc.aio.ServicerContext,
         readings_service: FromDishka[ReadingsService],
-    ):
+    ) -> collector_pb.DeleteReadingsResponse:
         logger.info("DeleteReadings called for %d devices", len(request.device_ids))
         try:
             await readings_service.delete_readings(list(request.device_ids))
@@ -49,12 +49,12 @@ class CollectorHandler(CollectorServiceServicer):
             raise
 
     @inject
-    async def GetReadings(
+    async def GetReadings(  # type: ignore[override]
         self,
-        request,
+        request: collector_pb.GetReadingsRequest,
         context: grpc.aio.ServicerContext,
         readings_service: FromDishka[ReadingsService],
-    ):
+    ) -> collector_pb.GetReadingsResponse:
         try:
             time_from = getattr(request, "from").ToDatetime(tzinfo=UTC)
             time_to = request.to.ToDatetime(tzinfo=UTC)
@@ -82,32 +82,32 @@ class CollectorHandler(CollectorServiceServicer):
         series: list[collector_pb.KeyReadings] = []
 
         if interval == 0:
-            data = await readings_service.get_readings_raw(
+            raw_data = await readings_service.get_readings_raw(
                 request.device_id, keys, time_from, time_to
             )
-            for key, readings in data.items():
+            for key, raw_readings in raw_data.items():
                 raw_points = []
-                for r in readings:
+                for r in raw_readings:
                     ts = Timestamp()
                     ts.FromDatetime(r.time)
                     raw_points.append(collector_pb.SensorReading(key=r.key, value=r.value, time=ts))
                 series.append(collector_pb.KeyReadings(key=key, raw_points=raw_points))
         else:
-            data = await readings_service.get_readings_aggregated(
+            agg_data = await readings_service.get_readings_aggregated(
                 request.device_id, keys, time_from, time_to, interval
             )
-            for key, readings in data.items():
+            for key, agg_readings in agg_data.items():
                 points = []
-                for r in readings:
+                for ar in agg_readings:
                     ts = Timestamp()
-                    ts.FromDatetime(r.time)
+                    ts.FromDatetime(ar.time)
                     point = collector_pb.AggregatedReading(time=ts)
-                    if r.avg is not None:
-                        point.avg = r.avg
-                    if r.min is not None:
-                        point.min = r.min
-                    if r.max is not None:
-                        point.max = r.max
+                    if ar.avg is not None:
+                        point.avg = ar.avg
+                    if ar.min is not None:
+                        point.min = ar.min
+                    if ar.max is not None:
+                        point.max = ar.max
                     points.append(point)
                 series.append(collector_pb.KeyReadings(key=key, points=points))
 

--- a/src/handlers/status.py
+++ b/src/handlers/status.py
@@ -3,12 +3,12 @@ import logging
 
 import grpc
 from placebrain_contracts import devices_pb2 as devices_pb
+from placebrain_contracts.devices_pb2 import DEVICE_STATUS_OFFLINE, DEVICE_STATUS_ONLINE
 from placebrain_contracts.devices_pb2_grpc import DevicesServiceStub
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_STATUS = 2  # offline
-_STATUS_MAP = {"online": 1, "offline": _DEFAULT_STATUS}
+_STATUS_MAP = {"online": DEVICE_STATUS_ONLINE, "offline": DEVICE_STATUS_OFFLINE}
 
 
 class StatusHandler:
@@ -31,7 +31,7 @@ class StatusHandler:
             return
 
         status_str = data.get("status", "offline")
-        proto_status = _STATUS_MAP.get(status_str, _DEFAULT_STATUS)
+        proto_status = _STATUS_MAP.get(status_str, DEVICE_STATUS_OFFLINE)
 
         try:
             await self._stub.UpdateDeviceStatus(

--- a/src/handlers/telemetry.py
+++ b/src/handlers/telemetry.py
@@ -61,7 +61,7 @@ class TelemetryHandler:
         for key, raw_value in values.items():
             try:
                 value = float(raw_value)
-            except (TypeError, ValueError):
+            except TypeError, ValueError:
                 logger.warning("Non-numeric value for key %s: %s", key, raw_value)
                 continue
 

--- a/src/main.py
+++ b/src/main.py
@@ -76,9 +76,8 @@ async def serve() -> None:
 
         async for message in client.messages:
             topic = str(message.topic)
-            payload = message.payload
-            if isinstance(payload, bytes):
-                payload = payload.decode()
+            raw_payload = message.payload
+            payload = raw_payload.decode() if isinstance(raw_payload, bytes) else str(raw_payload)
 
             if topic.endswith("/telemetry"):
                 await telemetry_handler.handle(topic, payload)

--- a/src/services/readings.py
+++ b/src/services/readings.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from typing import Any
 from uuid import UUID
 
 import asyncpg
@@ -60,7 +61,7 @@ class ReadingsService:
             ORDER BY key, time ASC
             LIMIT {MAX_ROWS}
         """
-        params: list = [UUID(device_id), time_from, time_to]
+        params: list[Any] = [UUID(device_id), time_from, time_to]
         if has_keys:
             params.append(keys)
 
@@ -99,7 +100,7 @@ class ReadingsService:
             ORDER BY key, bucket ASC
             LIMIT {MAX_ROWS}
         """
-        params: list = [interval, UUID(device_id), time_from, time_to]
+        params: list[Any] = [interval, UUID(device_id), time_from, time_to]
         if has_keys:
             params.append(keys)
 


### PR DESCRIPTION
## Summary
- Fix ruff formatting in `src/handlers/telemetry.py`
- Add mypy overrides for asyncpg and google.protobuf
- Add type annotations to gRPC handler methods in `readings.py`
- Fix proto enum usage in `status.py` (use named constants)
- Fix payload type handling in `main.py`
- Fix generic type params in `services/readings.py`
- Update placebrain-contracts to 0.12.0