### PR TITLE
feat: implement alerts RPC and include id/event_type in MQTT payload

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "faststream[kafka]>=0.5.0",
     "grpcio>=1.76.0",
     "orjson>=3.10.0",
-    "placebrain-contracts>=0.16.0",
+    "placebrain-contracts>=0.17.0",
     "pydantic-settings>=2.12.0",
     "redis[hiredis]>=6.0.0",
 ]

--- a/src/dependencies/services.py
+++ b/src/dependencies/services.py
@@ -4,6 +4,7 @@ from redis.asyncio import Redis
 
 from src.core.config import Settings
 from src.services.alerts import AlertService
+from src.services.alerts_query import AlertsService
 from src.services.buffer import TelemetryBuffer
 from src.services.readings import ReadingsService
 from src.services.threshold_cache import ThresholdCache
@@ -30,3 +31,7 @@ class ServicesProvider(Provider):
     @provide(scope=Scope.REQUEST)
     def provide_readings_service(self, pool: asyncpg.Pool) -> ReadingsService:
         return ReadingsService(pool)
+
+    @provide(scope=Scope.REQUEST)
+    def provide_alerts_service(self, pool: asyncpg.Pool) -> AlertsService:
+        return AlertsService(pool)

--- a/src/handlers/readings.py
+++ b/src/handlers/readings.py
@@ -219,17 +219,5 @@ class CollectorHandler(CollectorServiceServicer):
             await context.abort(grpc.StatusCode.NOT_FOUND, "Alert not found")
             raise RuntimeError("unreachable")
 
-        await alert_service.publish_resolved(
-            alert_id=row.id,
-            sensor_id=row.sensor_id,
-            threshold_id=row.threshold_id,
-            device_id=row.device_id,
-            place_id=row.place_id,
-            key=row.key,
-            value=row.value,
-            threshold_value=row.threshold_value,
-            threshold_type=row.threshold_type,
-            severity=row.severity,
-            resolved_at=row.resolved_at,
-        )
+        await alert_service.publish_resolved(row)
         return collector_pb.ResolveAlertResponse(alert=_alert_to_proto(row))

--- a/src/handlers/readings.py
+++ b/src/handlers/readings.py
@@ -8,9 +8,53 @@ from google.protobuf.timestamp_pb2 import Timestamp
 from placebrain_contracts import collector_pb2 as collector_pb
 from placebrain_contracts.collector_pb2_grpc import CollectorServiceServicer
 
+from src.services.alerts import AlertService
+from src.services.alerts_query import AlertRow, AlertsService
 from src.services.readings import MAX_RAW_RANGE_HOURS, ReadingsService
 
 logger = logging.getLogger(__name__)
+
+
+_THRESHOLD_TYPE_TO_PROTO = {
+    "min": collector_pb.ALERT_THRESHOLD_TYPE_MIN,
+    "max": collector_pb.ALERT_THRESHOLD_TYPE_MAX,
+}
+_SEVERITY_TO_PROTO = {
+    "warning": collector_pb.ALERT_SEVERITY_WARNING,
+    "critical": collector_pb.ALERT_SEVERITY_CRITICAL,
+}
+_STATUS_TO_PROTO = {
+    "active": collector_pb.ALERT_STATUS_ACTIVE,
+    "resolved": collector_pb.ALERT_STATUS_RESOLVED,
+}
+_PROTO_TO_STATUS = {v: k for k, v in _STATUS_TO_PROTO.items()}
+_PROTO_TO_SEVERITY = {v: k for k, v in _SEVERITY_TO_PROTO.items()}
+
+
+def _alert_to_proto(row: AlertRow) -> collector_pb.Alert:
+    created_ts = Timestamp()
+    created_ts.FromDatetime(row.created_at)
+    msg = collector_pb.Alert(
+        id=row.id,
+        sensor_id=row.sensor_id,
+        threshold_id=row.threshold_id,
+        device_id=row.device_id,
+        place_id=row.place_id,
+        key=row.key,
+        value=row.value,
+        threshold_value=row.threshold_value,
+        threshold_type=_THRESHOLD_TYPE_TO_PROTO.get(
+            row.threshold_type, collector_pb.ALERT_THRESHOLD_TYPE_UNSPECIFIED
+        ),
+        severity=_SEVERITY_TO_PROTO.get(row.severity, collector_pb.ALERT_SEVERITY_UNSPECIFIED),
+        status=_STATUS_TO_PROTO.get(row.status, collector_pb.ALERT_STATUS_UNSPECIFIED),
+        created_at=created_ts,
+    )
+    if row.resolved_at is not None:
+        resolved_ts = Timestamp()
+        resolved_ts.FromDatetime(row.resolved_at)
+        msg.resolved_at.CopyFrom(resolved_ts)
+    return msg
 
 
 class CollectorHandler(CollectorServiceServicer):
@@ -97,3 +141,95 @@ class CollectorHandler(CollectorServiceServicer):
                 series.append(collector_pb.KeyReadings(key=key, points=points))
 
         return collector_pb.GetReadingsResponse(series=series)
+
+    @inject
+    async def GetAlerts(  # type: ignore[override]
+        self,
+        request: collector_pb.GetAlertsRequest,
+        context: grpc.aio.ServicerContext,
+        alerts_service: FromDishka[AlertsService],
+    ) -> collector_pb.GetAlertsResponse:
+        try:
+            status = _PROTO_TO_STATUS.get(request.status) if request.HasField("status") else None
+            severity = (
+                _PROTO_TO_SEVERITY.get(request.severity) if request.HasField("severity") else None
+            )
+            sensor_id = request.sensor_id if request.HasField("sensor_id") else None
+            device_id = request.device_id if request.HasField("device_id") else None
+            time_from = (
+                getattr(request, "from").ToDatetime(tzinfo=UTC)
+                if request.HasField("from")
+                else None
+            )
+            time_to = request.to.ToDatetime(tzinfo=UTC) if request.HasField("to") else None
+
+            items, total = await alerts_service.list_alerts(
+                place_id=request.place_id,
+                status=status,
+                severity=severity,
+                sensor_id=sensor_id,
+                device_id=device_id,
+                time_from=time_from,
+                time_to=time_to,
+                page=request.page,
+                per_page=request.per_page,
+            )
+        except ValueError as e:
+            await context.abort(grpc.StatusCode.INVALID_ARGUMENT, f"Invalid argument: {e}")
+            raise
+
+        return collector_pb.GetAlertsResponse(
+            items=[_alert_to_proto(it) for it in items],
+            total=total,
+        )
+
+    @inject
+    async def GetAlertCounts(  # type: ignore[override]
+        self,
+        request: collector_pb.GetAlertCountsRequest,
+        context: grpc.aio.ServicerContext,
+        alerts_service: FromDishka[AlertsService],
+    ) -> collector_pb.GetAlertCountsResponse:
+        try:
+            per_place, total = await alerts_service.count_unresolved(list(request.place_id))
+        except ValueError as e:
+            await context.abort(grpc.StatusCode.INVALID_ARGUMENT, f"Invalid place_id: {e}")
+            raise
+
+        response = collector_pb.GetAlertCountsResponse(total_unresolved=total)
+        for place_id, cnt in per_place.items():
+            response.unresolved_by_place[place_id] = cnt
+        return response
+
+    @inject
+    async def ResolveAlert(  # type: ignore[override]
+        self,
+        request: collector_pb.ResolveAlertRequest,
+        context: grpc.aio.ServicerContext,
+        alerts_service: FromDishka[AlertsService],
+        alert_service: FromDishka[AlertService],
+    ) -> collector_pb.ResolveAlertResponse:
+        try:
+            row = await alerts_service.resolve(request.alert_id)
+        except ValueError as e:
+            await context.abort(grpc.StatusCode.INVALID_ARGUMENT, f"Invalid alert_id: {e}")
+            raise
+
+        if row is None:
+            await context.abort(grpc.StatusCode.NOT_FOUND, "Alert not found")
+            raise RuntimeError("unreachable")
+
+        await alert_service.publish_resolved(
+            alert_id=row.id,
+            sensor_id=row.sensor_id,
+            threshold_id=row.threshold_id,
+            device_id=row.device_id,
+            place_id=row.place_id,
+            key=row.key,
+            value=row.value,
+            threshold_value=row.threshold_value,
+            threshold_type=row.threshold_type,
+            severity=row.severity,
+            resolved_at=row.resolved_at,
+        )
+        return collector_pb.ResolveAlertResponse(alert=_alert_to_proto(row))

--- a/src/services/alerts.py
+++ b/src/services/alerts.py
@@ -1,14 +1,33 @@
 import json
 import logging
-from datetime import datetime
+from datetime import UTC, datetime
 from uuid import UUID
 
 import aiomqtt
 import asyncpg
 
+from src.services.alerts_query import AlertRow
 from src.services.threshold_cache import SensorMapping, ThresholdInfo
 
 logger = logging.getLogger(__name__)
+
+
+def _alert_payload(row: AlertRow, event_type: str) -> dict[str, object]:
+    return {
+        "id": row.id,
+        "event_type": event_type,
+        "sensor_id": row.sensor_id,
+        "threshold_id": row.threshold_id,
+        "device_id": row.device_id,
+        "place_id": row.place_id,
+        "key": row.key,
+        "value": row.value,
+        "threshold_value": row.threshold_value,
+        "threshold_type": row.threshold_type,
+        "severity": row.severity,
+        "created_at": row.created_at.isoformat(),
+        "resolved_at": row.resolved_at.isoformat() if row.resolved_at else None,
+    }
 
 
 class AlertService:
@@ -43,13 +62,13 @@ class AlertService:
     ) -> None:
         try:
             async with self._pool.acquire() as conn:
-                row = await conn.fetchrow(
+                inserted = await conn.fetchrow(
                     """
                     INSERT INTO alerts (
                         sensor_id, threshold_id, device_id, place_id,
                         key, value, threshold_value, threshold_type, severity
                     ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-                    RETURNING id
+                    RETURNING id, created_at
                     """,
                     UUID(mapping.sensor_id),
                     UUID(threshold.threshold_id),
@@ -65,70 +84,40 @@ class AlertService:
             logger.exception("Failed to write alert to DB")
             return
 
-        alert_id = str(row["id"])
-        alert_payload = {
-            "id": alert_id,
-            "event_type": "created",
-            "sensor_id": mapping.sensor_id,
-            "device_id": mapping.device_id,
-            "place_id": place_id,
-            "key": mapping.key,
-            "value": value,
-            "threshold_id": threshold.threshold_id,
-            "threshold_type": threshold.threshold_type,
-            "threshold_value": threshold.value,
-            "severity": threshold.severity,
-            "timestamp": timestamp.isoformat(),
-        }
+        row = AlertRow(
+            id=str(inserted["id"]),
+            sensor_id=mapping.sensor_id,
+            threshold_id=threshold.threshold_id,
+            device_id=mapping.device_id,
+            place_id=place_id,
+            key=mapping.key,
+            value=value,
+            threshold_value=threshold.value,
+            threshold_type=threshold.threshold_type,
+            severity=threshold.severity,
+            status="active",
+            created_at=inserted["created_at"] or timestamp.astimezone(UTC),
+            resolved_at=None,
+        )
+        await self._publish(row, "created")
+        logger.warning(
+            "Alert: %s %s=%s exceeds %s threshold %s (severity=%s)",
+            row.key,
+            row.device_id,
+            row.value,
+            row.threshold_type,
+            row.threshold_value,
+            row.severity,
+        )
 
-        topic = f"placebrain/{place_id}/alerts"
-        if self._client:
-            try:
-                await self._client.publish(topic, json.dumps(alert_payload))
-                logger.warning(
-                    "Alert: %s %s=%s exceeds %s threshold %s (severity=%s)",
-                    mapping.key,
-                    mapping.device_id,
-                    value,
-                    threshold.threshold_type,
-                    threshold.value,
-                    threshold.severity,
-                )
-            except aiomqtt.MqttError:
-                logger.exception("Failed to publish alert to MQTT")
+    async def publish_resolved(self, row: AlertRow) -> None:
+        await self._publish(row, "resolved")
 
-    async def publish_resolved(
-        self,
-        *,
-        alert_id: str,
-        sensor_id: str,
-        threshold_id: str,
-        device_id: str,
-        place_id: str,
-        key: str,
-        value: float,
-        threshold_value: float,
-        threshold_type: str,
-        severity: str,
-        resolved_at: datetime | None,
-    ) -> None:
-        payload = {
-            "id": alert_id,
-            "event_type": "resolved",
-            "sensor_id": sensor_id,
-            "device_id": device_id,
-            "place_id": place_id,
-            "key": key,
-            "value": value,
-            "threshold_id": threshold_id,
-            "threshold_type": threshold_type,
-            "threshold_value": threshold_value,
-            "severity": severity,
-            "resolved_at": resolved_at.isoformat() if resolved_at is not None else None,
-        }
-        topic = f"placebrain/{place_id}/alerts"
-        if self._client:
-            try:
-                await self._client.publish(topic, json.dumps(payload))
-            except aiomqtt.MqttError:
-                logger.exception("Failed to publish resolved alert to MQTT")
+    async def _publish(self, row: AlertRow, event_type: str) -> None:
+        if not self._client:
+            return
+        topic = f"placebrain/{row.place_id}/alerts"
+        try:
+            await self._client.publish(topic, json.dumps(_alert_payload(row, event_type)))
+        except aiomqtt.MqttError:
+            logger.exception("Failed to publish %s alert to MQTT", event_type)

--- a/src/services/alerts.py
+++ b/src/services/alerts.py
@@ -41,11 +41,40 @@ class AlertService:
         timestamp: datetime,
         place_id: str,
     ) -> None:
+        try:
+            async with self._pool.acquire() as conn:
+                row = await conn.fetchrow(
+                    """
+                    INSERT INTO alerts (
+                        sensor_id, threshold_id, device_id, place_id,
+                        key, value, threshold_value, threshold_type, severity
+                    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+                    RETURNING id
+                    """,
+                    UUID(mapping.sensor_id),
+                    UUID(threshold.threshold_id),
+                    UUID(mapping.device_id),
+                    UUID(place_id),
+                    mapping.key,
+                    value,
+                    threshold.value,
+                    threshold.threshold_type,
+                    threshold.severity,
+                )
+        except asyncpg.PostgresError:
+            logger.exception("Failed to write alert to DB")
+            return
+
+        alert_id = str(row["id"])
         alert_payload = {
+            "id": alert_id,
+            "event_type": "created",
             "sensor_id": mapping.sensor_id,
             "device_id": mapping.device_id,
+            "place_id": place_id,
             "key": mapping.key,
             "value": value,
+            "threshold_id": threshold.threshold_id,
             "threshold_type": threshold.threshold_type,
             "threshold_value": threshold.value,
             "severity": threshold.severity,
@@ -68,24 +97,38 @@ class AlertService:
             except aiomqtt.MqttError:
                 logger.exception("Failed to publish alert to MQTT")
 
-        try:
-            async with self._pool.acquire() as conn:
-                await conn.execute(
-                    """
-                    INSERT INTO alerts (
-                        sensor_id, threshold_id, device_id, place_id,
-                        key, value, threshold_value, threshold_type, severity
-                    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-                    """,
-                    UUID(mapping.sensor_id),
-                    UUID(threshold.threshold_id),
-                    UUID(mapping.device_id),
-                    UUID(place_id),
-                    mapping.key,
-                    value,
-                    threshold.value,
-                    threshold.threshold_type,
-                    threshold.severity,
-                )
-        except asyncpg.PostgresError:
-            logger.exception("Failed to write alert to DB")
+    async def publish_resolved(
+        self,
+        *,
+        alert_id: str,
+        sensor_id: str,
+        threshold_id: str,
+        device_id: str,
+        place_id: str,
+        key: str,
+        value: float,
+        threshold_value: float,
+        threshold_type: str,
+        severity: str,
+        resolved_at: datetime | None,
+    ) -> None:
+        payload = {
+            "id": alert_id,
+            "event_type": "resolved",
+            "sensor_id": sensor_id,
+            "device_id": device_id,
+            "place_id": place_id,
+            "key": key,
+            "value": value,
+            "threshold_id": threshold_id,
+            "threshold_type": threshold_type,
+            "threshold_value": threshold_value,
+            "severity": severity,
+            "resolved_at": resolved_at.isoformat() if resolved_at is not None else None,
+        }
+        topic = f"placebrain/{place_id}/alerts"
+        if self._client:
+            try:
+                await self._client.publish(topic, json.dumps(payload))
+            except aiomqtt.MqttError:
+                logger.exception("Failed to publish resolved alert to MQTT")

--- a/src/services/alerts_query.py
+++ b/src/services/alerts_query.py
@@ -1,0 +1,143 @@
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+import asyncpg
+
+DEFAULT_PAGE_SIZE = 50
+MAX_PAGE_SIZE = 200
+
+
+@dataclass
+class AlertRow:
+    id: str
+    sensor_id: str
+    threshold_id: str
+    device_id: str
+    place_id: str
+    key: str
+    value: float
+    threshold_value: float
+    threshold_type: str
+    severity: str
+    status: str
+    created_at: datetime
+    resolved_at: datetime | None
+
+
+def _row_to_alert(row: asyncpg.Record) -> AlertRow:
+    return AlertRow(
+        id=str(row["id"]),
+        sensor_id=str(row["sensor_id"]),
+        threshold_id=str(row["threshold_id"]),
+        device_id=str(row["device_id"]),
+        place_id=str(row["place_id"]),
+        key=row["key"],
+        value=row["value"],
+        threshold_value=row["threshold_value"],
+        threshold_type=row["threshold_type"],
+        severity=row["severity"],
+        status=row["status"],
+        created_at=row["created_at"],
+        resolved_at=row["resolved_at"],
+    )
+
+
+class AlertsService:
+    def __init__(self, pool: asyncpg.Pool) -> None:
+        self._pool = pool
+
+    async def list_alerts(
+        self,
+        place_id: str,
+        status: str | None,
+        severity: str | None,
+        sensor_id: str | None,
+        device_id: str | None,
+        time_from: datetime | None,
+        time_to: datetime | None,
+        page: int,
+        per_page: int,
+    ) -> tuple[list[AlertRow], int]:
+        if per_page <= 0:
+            per_page = DEFAULT_PAGE_SIZE
+        per_page = min(per_page, MAX_PAGE_SIZE)
+        if page <= 0:
+            page = 1
+
+        conditions: list[str] = ["place_id = $1::uuid"]
+        params: list[Any] = [UUID(place_id)]
+
+        if status:
+            params.append(status)
+            conditions.append(f"status = ${len(params)}")
+        if severity:
+            params.append(severity)
+            conditions.append(f"severity = ${len(params)}")
+        if sensor_id:
+            params.append(UUID(sensor_id))
+            conditions.append(f"sensor_id = ${len(params)}::uuid")
+        if device_id:
+            params.append(UUID(device_id))
+            conditions.append(f"device_id = ${len(params)}::uuid")
+        if time_from is not None:
+            params.append(time_from)
+            conditions.append(f"created_at >= ${len(params)}")
+        if time_to is not None:
+            params.append(time_to)
+            conditions.append(f"created_at < ${len(params)}")
+
+        where = " AND ".join(conditions)
+        offset = (page - 1) * per_page
+
+        list_query = f"""
+            SELECT id, sensor_id, threshold_id, device_id, place_id,
+                   key, value, threshold_value, threshold_type, severity,
+                   status, created_at, resolved_at
+            FROM alerts
+            WHERE {where}
+            ORDER BY created_at DESC
+            LIMIT {per_page} OFFSET {offset}
+        """
+        count_query = f"SELECT COUNT(*) AS total FROM alerts WHERE {where}"
+
+        async with self._pool.acquire() as conn:
+            rows = await conn.fetch(list_query, *params)
+            total_row = await conn.fetchrow(count_query, *params)
+
+        items = [_row_to_alert(r) for r in rows]
+        total = int(total_row["total"]) if total_row else 0
+        return items, total
+
+    async def count_unresolved(self, place_ids: list[str]) -> tuple[dict[str, int], int]:
+        if not place_ids:
+            return {}, 0
+        uuids = [UUID(p) for p in place_ids]
+        query = """
+            SELECT place_id, COUNT(*) AS cnt
+            FROM alerts
+            WHERE status = 'active' AND place_id = ANY($1::uuid[])
+            GROUP BY place_id
+        """
+        async with self._pool.acquire() as conn:
+            rows = await conn.fetch(query, uuids)
+
+        per_place: dict[str, int] = {str(r["place_id"]): int(r["cnt"]) for r in rows}
+        total = sum(per_place.values())
+        return per_place, total
+
+    async def resolve(self, alert_id: str) -> AlertRow | None:
+        query = """
+            UPDATE alerts
+            SET status = 'resolved', resolved_at = NOW()
+            WHERE id = $1::uuid AND status != 'resolved'
+            RETURNING id, sensor_id, threshold_id, device_id, place_id,
+                      key, value, threshold_value, threshold_type, severity,
+                      status, created_at, resolved_at
+        """
+        async with self._pool.acquire() as conn:
+            row = await conn.fetchrow(query, UUID(alert_id))
+        if row is None:
+            return None
+        return _row_to_alert(row)

--- a/uv.lock
+++ b/uv.lock
@@ -356,7 +356,7 @@ requires-dist = [
     { name = "faststream", extras = ["kafka"], specifier = ">=0.5.0" },
     { name = "grpcio", specifier = ">=1.76.0" },
     { name = "orjson", specifier = ">=3.10.0" },
-    { name = "placebrain-contracts", specifier = ">=0.16.0" },
+    { name = "placebrain-contracts", specifier = ">=0.17.0" },
     { name = "pydantic-settings", specifier = ">=2.12.0" },
     { name = "redis", extras = ["hiredis"], specifier = ">=6.0.0" },
 ]
@@ -369,16 +369,16 @@ dev = [
 
 [[package]]
 name = "placebrain-contracts"
-version = "0.16.0"
+version = "0.17.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "grpcio" },
     { name = "protobuf" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1a/e5/53bcdc53c111ff7d24dc9f282af9d1d18475b611ed7ff0b5a317a896f93b/placebrain_contracts-0.16.0.tar.gz", hash = "sha256:c720b799fc60bfb5fc8a3536f2c701ab84b213c39280050e64bd30b6f319fb2f", size = 37135, upload-time = "2026-04-16T15:33:10.889Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/16/9c1cfe9500e999820a151e9ea2f3cd9169a7d6f210c5d251470717566906/placebrain_contracts-0.17.0.tar.gz", hash = "sha256:98bb5c63a2cd9cb0c4358255a47c6792009a6b3248783e07f91a42a2f0883454", size = 47197, upload-time = "2026-04-16T22:59:10.69Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/7b/bbb044fd3bdddf8aa239f393e184e27ef8974c3f569753a6def95485737f/placebrain_contracts-0.16.0-py3-none-any.whl", hash = "sha256:04473700cbe22aab8d466fdffefdb7be1dbc6379665888bb262b2f67d67f48f6", size = 33342, upload-time = "2026-04-16T15:33:11.714Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/68/18642607b5e62c9b2e5ce8e93ab24acc3f65624f58c3f343ad5851b103f2/placebrain_contracts-0.17.0-py3-none-any.whl", hash = "sha256:eee13bdb245c4ee90628bfdc99280241efb9cab2ea39db164226a9bb6fcd3a40", size = 41739, upload-time = "2026-04-16T22:59:11.694Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Adds the three alert RPCs on `CollectorService` (`GetAlerts`, `GetAlertCounts`, `ResolveAlert`) so the gateway/frontend can read history, badge counts, and resolve alerts. Also includes `id` and `event_type` in the MQTT alert payload so live events can be correlated with DB rows.

## Changes
- New `AlertsService` (raw asyncpg) with paginated list, per-place unresolved counts, and resolve-with-RETURNING.
- New gRPC handlers in `CollectorHandler` mapping enum filters to DB strings and Alert rows back to proto.
- `AlertService._create_alert`: insert with `RETURNING id`, then publish MQTT payload with `id`, `event_type='created'`, plus `threshold_id`/`place_id`.
- `AlertService.publish_resolved`: typed helper to publish `event_type='resolved'`, called by `ResolveAlert`.
- DI wires `AlertsService` (REQUEST scope).
- Bump `placebrain-contracts` to `>=0.17.0`.

## Verification
- [x] `uv run ruff format --check`, `uv run ruff check`, `uv run mypy src` — green.
- [x] `make dev` — full stack healthy after rebuild.
- [x] gRPC `GetAlerts(place_id, page=1, per_page=3)` against existing alerts → 125 total, 3 items returned with correct mapping.
- [x] gRPC `GetAlertCounts([p1, p2])` → correct per-place counts and `total_unresolved=148`.
- [x] gRPC `ResolveAlert(id)` → DB row flipped to `resolved` with `resolved_at`, MQTT payload `event_type=resolved` received with the alert `id`.
- [x] `AlertService.evaluate_and_alert` invoked directly → DB insert + MQTT payload with new `id` and `event_type=created`.
- [ ] Full EMQX→Kafka telemetry pipeline triggering an alert: not exercised. The pre-existing `EmqxTelemetryMessage` shape mismatches what EMQX actually publishes (raw payload, no `{topic, payload}` envelope), and `ThresholdCache._local_cache` is never populated from `ThresholdCreated` events. Both are pre-existing bugs unrelated to this issue; raise as separate work.

Closes #3