### PR TITLE
fix: populate threshold cache with device_id/key so alerts fire

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "faststream[kafka]>=0.5.0",
     "grpcio>=1.76.0",
     "orjson>=3.10.0",
-    "placebrain-contracts>=0.17.0",
+    "placebrain-contracts>=0.18.0",
     "pydantic-settings>=2.12.0",
     "redis[hiredis]>=6.0.0",
 ]

--- a/src/infra/broker/routes.py
+++ b/src/infra/broker/routes.py
@@ -60,6 +60,8 @@ async def on_threshold_created(
         threshold_type=event.threshold_type,
         value=event.value,
         severity=event.severity,
+        device_id=str(event.device_id),
+        key=event.key,
     )
     logger.info("Threshold cache updated: sensor=%s", event.sensor_id)
 
@@ -69,7 +71,12 @@ async def on_threshold_deleted(
     event: ThresholdDeleted,
     cache: FromDishka[ThresholdCache],
 ) -> None:
-    await cache.remove_threshold(str(event.sensor_id), str(event.threshold_id))
+    await cache.remove_threshold(
+        sensor_id=str(event.sensor_id),
+        threshold_id=str(event.threshold_id),
+        device_id=str(event.device_id),
+        key=event.key,
+    )
     logger.info("Threshold removed from cache: %s", event.threshold_id)
 
 

--- a/src/services/threshold_cache.py
+++ b/src/services/threshold_cache.py
@@ -71,17 +71,27 @@ class ThresholdCache:
         if device_id and key:
             self._update_local_cache(device_id, key, sensor_id, thresholds)
 
-    async def remove_threshold(self, sensor_id: str, threshold_id: str) -> None:
+    async def remove_threshold(
+        self,
+        sensor_id: str,
+        threshold_id: str,
+        device_id: str = "",
+        key: str = "",
+    ) -> None:
         redis_key = f"thresholds:{sensor_id}"
         raw = await self._redis.get(redis_key)
-        if not raw:
-            return
-        thresholds: list[dict[str, Any]] = orjson.loads(raw)
+        thresholds: list[dict[str, Any]] = orjson.loads(raw) if raw else []
         thresholds = [t for t in thresholds if t["threshold_id"] != threshold_id]
         if thresholds:
             await self._redis.set(redis_key, orjson.dumps(thresholds))
         else:
             await self._redis.delete(redis_key)
+
+        if device_id and key:
+            if thresholds:
+                self._update_local_cache(device_id, key, sensor_id, thresholds)
+            else:
+                self._local_cache.pop((device_id, key), None)
 
     async def delete_readings_for_devices(self, device_ids: list[str]) -> None:
         """Clean up threshold cache entries for deleted devices."""

--- a/uv.lock
+++ b/uv.lock
@@ -356,7 +356,7 @@ requires-dist = [
     { name = "faststream", extras = ["kafka"], specifier = ">=0.5.0" },
     { name = "grpcio", specifier = ">=1.76.0" },
     { name = "orjson", specifier = ">=3.10.0" },
-    { name = "placebrain-contracts", specifier = ">=0.17.0" },
+    { name = "placebrain-contracts", specifier = ">=0.18.0" },
     { name = "pydantic-settings", specifier = ">=2.12.0" },
     { name = "redis", extras = ["hiredis"], specifier = ">=6.0.0" },
 ]
@@ -369,16 +369,16 @@ dev = [
 
 [[package]]
 name = "placebrain-contracts"
-version = "0.17.0"
+version = "0.18.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "grpcio" },
     { name = "protobuf" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/16/9c1cfe9500e999820a151e9ea2f3cd9169a7d6f210c5d251470717566906/placebrain_contracts-0.17.0.tar.gz", hash = "sha256:98bb5c63a2cd9cb0c4358255a47c6792009a6b3248783e07f91a42a2f0883454", size = 47197, upload-time = "2026-04-16T22:59:10.69Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/6a/d451207ebbe56a2453312c980680bb0b0ae9b5d1d361be830b8fe5489a8c/placebrain_contracts-0.18.0.tar.gz", hash = "sha256:a8afeb93052665fabc61560118b9b87aaa59f011f2cba947171410b0efb9f0c9", size = 47256, upload-time = "2026-04-16T23:31:53.018Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/68/18642607b5e62c9b2e5ce8e93ab24acc3f65624f58c3f343ad5851b103f2/placebrain_contracts-0.17.0-py3-none-any.whl", hash = "sha256:eee13bdb245c4ee90628bfdc99280241efb9cab2ea39db164226a9bb6fcd3a40", size = 41739, upload-time = "2026-04-16T22:59:11.694Z" },
+    { url = "https://files.pythonhosted.org/packages/42/6d/9269fa6a8dcf696f2f40884d19386c963894b8af78c8db3c75e923744060/placebrain_contracts-0.18.0-py3-none-any.whl", hash = "sha256:87eaee60c4937358d68a24a22929eb4a74a8f90f87981d461ea2157ef106c007", size = 41755, upload-time = "2026-04-16T23:31:54.225Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Подписчики `ThresholdCreated`/`ThresholdDeleted` теперь прокидывают `device_id` и `key` (появились в contracts 0.18.0) в `ThresholdCache`, благодаря чему `_local_cache` действительно заполняется и `cache.lookup(device_id, key)` возвращает `SensorMapping` — алерты на телеметрии перестают молча проскакивать.

## Changes

- `src/infra/broker/routes.py`: передаю `device_id=str(event.device_id)` и `key=event.key` в `cache.set_threshold(...)` и `cache.remove_threshold(...)`.
- `src/services/threshold_cache.py`: `remove_threshold` принимает опциональные `device_id`/`key` и обновляет/удаляет соответствующую запись в локальном кеше, чтобы не висел устаревший `ThresholdInfo`.
- `pyproject.toml`: bump `placebrain-contracts` до `>=0.18.0`.
- `uv.lock`: regenerate.

## Verification

- [x] `uv run ruff check`, `uv run ruff format --check`, `uv run mypy src` — без ошибок.
- [x] Полный сквозной smoke на свежепересобранном `make dev`:
  - login через `POST /api/auth/login` под существующим юзером;
  - создан device + sensor (`key=temperature`) + threshold (`max=30, severity=warning`) через `POST /api/places/...`;
  - в логах collector: `Threshold cache updated: sensor=019d98b6-...`; в Redis (`thresholds:<sensor_id>` в db 1) появилась запись;
  - симулятор (`simulator/emulator.py` с `SPIKE_CHANCE=1.0`) опубликовал 6 telemetry-сообщений `temperature ∈ [37.3, 41.0]` через MQTT;
  - в `telemetry_db.alerts` записалось ровно 6 строк с `value > 30`, `threshold_value=30`, `severity=warning`;
  - в логах collector нет ошибок MQTT-публикации (отсутствие `Failed to publish ... alert to MQTT` в `AlertService._publish`), значит сообщения ушли на `placebrain/{place_id}/alerts`.

Closes #5